### PR TITLE
Save disclosure status and inderes recommendations in order to resume state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
     implementation 'org.apache.logging.log4j:log4j-api:2.14.1'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.99'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.mockito:mockito-core:4.0.0'

--- a/src/main/java/com/etsubu/stonksbot/configuration/Config.java
+++ b/src/main/java/com/etsubu/stonksbot/configuration/Config.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 @NoArgsConstructor
 public class Config {
     private String oauth;
+    private S3Config s3;
     private FeatureConfig omxhNews;
     private FeatureConfig shareville;
     private List<String> globalAdmins;
@@ -41,5 +42,9 @@ public class Config {
 
     public FeatureConfig getShareville() {
         return Optional.ofNullable(shareville).orElseGet(() -> new FeatureConfig("false"));
+    }
+
+    public S3Config getS3() {
+        return s3;
     }
 }

--- a/src/main/java/com/etsubu/stonksbot/configuration/ConfigLoader.java
+++ b/src/main/java/com/etsubu/stonksbot/configuration/ConfigLoader.java
@@ -15,7 +15,6 @@ import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.Optional;
 
-@Component
 public class ConfigLoader {
     private static final Logger log = LoggerFactory.getLogger(ConfigLoader.class);
     private static final Config DEFAULT_CONFIG = new Config();

--- a/src/main/java/com/etsubu/stonksbot/configuration/ConfigurationSync.java
+++ b/src/main/java/com/etsubu/stonksbot/configuration/ConfigurationSync.java
@@ -1,0 +1,8 @@
+package com.etsubu.stonksbot.configuration;
+
+import java.util.Optional;
+
+public interface ConfigurationSync {
+    <T> Optional<T> loadConfiguration(String key, Class<T> c);
+    boolean saveConfiguration(String key, Object content);
+}

--- a/src/main/java/com/etsubu/stonksbot/configuration/LocalSync.java
+++ b/src/main/java/com/etsubu/stonksbot/configuration/LocalSync.java
@@ -1,0 +1,56 @@
+package com.etsubu.stonksbot.configuration;
+
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+public class LocalSync implements ConfigurationSync {
+    private static final Logger log = LoggerFactory.getLogger(LocalSync.class);
+    private final Path path = Paths.get("configs");
+    private final Gson gson;
+
+    public LocalSync() {
+        if(!Files.exists(path)) {
+            try {
+                Files.createDirectory(path);
+            } catch (IOException e) {
+                log.error("Failed to create directory for local configs");
+            }
+        }
+        gson = new Gson();
+    }
+    @Override
+    public <T> Optional<T> loadConfiguration(String key, Class<T> c) {
+        Path configPath = path.resolve(key);
+        if(!Files.exists(configPath)) {
+            return Optional.empty();
+        }
+        try {
+            log.info("Loading configuration with key='{}'", key);
+            return Optional.of(gson.fromJson(Files.readString(configPath, StandardCharsets.UTF_8), c));
+        } catch (Exception e) {
+            log.error("Failed to read config path {}", configPath.toAbsolutePath(), e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public boolean saveConfiguration(String key, Object content) {
+        Path configPath = path.resolve(key);
+        try {
+            Files.writeString(configPath, gson.toJson(content));
+            log.info("Saved config with key='{}'", key);
+            return true;
+        } catch (IOException e) {
+            log.error("Failed to save config to path {}", configPath.toAbsolutePath(), e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/etsubu/stonksbot/configuration/S3CloudSync.java
+++ b/src/main/java/com/etsubu/stonksbot/configuration/S3CloudSync.java
@@ -1,0 +1,64 @@
+package com.etsubu.stonksbot.configuration;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3Object;
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Cloud sync implementation against AWS S3
+ * @author etsubu
+ */
+public class S3CloudSync implements ConfigurationSync {
+    private static final Logger log = LoggerFactory.getLogger(S3CloudSync.class);
+    private final ConfigLoader configLoader;
+    private final AmazonS3 s3;
+    private final Gson gson;
+
+    public S3CloudSync(ConfigLoader configLoader) {
+        this.configLoader = configLoader;
+        S3Config s3Config = configLoader.getConfig().getS3();
+        if(s3Config == null) {
+            log.info("S3 bucket for cloud sync configured");
+            throw new IllegalArgumentException("No S3 bucket configured");
+        }
+        gson = new Gson();
+        final var builder = AmazonS3ClientBuilder.standard();
+        Optional.ofNullable(s3Config.getRegion()).ifPresentOrElse(builder::withRegion, ()-> builder.withRegion(Regions.DEFAULT_REGION));
+        s3 = builder.build();
+    }
+
+    @Override
+    public <T> Optional<T> loadConfiguration(String key, Class<T> c) {
+        String base = Optional.ofNullable(configLoader.getConfig().getS3()).map(S3Config::getS3bucket).orElse(null);
+        if(base == null) {
+            log.error("S3 bucket is missing");
+        }
+        try {
+            S3Object obj = s3.getObject(base, key);
+            return Optional.of(gson.fromJson(new String(obj.getObjectContent().readAllBytes(), StandardCharsets.UTF_8), c));
+        } catch (Exception e) {
+            log.error("Failed to load item from s3, key='{}', bucket='{}'", key, base, e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean saveConfiguration(String key, Object content) {
+        String base = Optional.ofNullable(configLoader.getConfig().getS3()).map(S3Config::getS3bucket).orElse(null);
+        try {
+            s3.putObject(base, key, gson.toJson(content));
+            log.info("Saved to s3, key='{}', bucket='{}'", key, base);
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to save config with key='{}' and bucket='{}' to s3 ", key, base, e);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/etsubu/stonksbot/configuration/S3Config.java
+++ b/src/main/java/com/etsubu/stonksbot/configuration/S3Config.java
@@ -1,0 +1,13 @@
+package com.etsubu.stonksbot.configuration;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class S3Config {
+    private String s3bucket;
+    private String region;
+}

--- a/src/main/java/com/etsubu/stonksbot/configuration/SpringConfig.java
+++ b/src/main/java/com/etsubu/stonksbot/configuration/SpringConfig.java
@@ -10,12 +10,31 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @Configuration
 public class SpringConfig {
     private static final Logger log = LoggerFactory.getLogger(SpringConfig.class);
+
     @Bean
-    public TaskScheduler taskScheduler() {
+    public ConfigLoader configLoaderBean() {
+        return new ConfigLoader();
+    }
+    @Bean
+    public TaskScheduler taskSchedulerBean() {
         var scheduler = new ThreadPoolTaskScheduler();
         int poolSize = Runtime.getRuntime().availableProcessors() * 2;
         scheduler.setPoolSize(poolSize);
         log.info("Created task scheduler with pool size '{}'", poolSize);
         return scheduler;
+    }
+
+    @Bean
+    public ConfigurationSync configurationSyncBean(ConfigLoader configLoader) {
+        if(configLoader.getConfig().getS3() != null) {
+            log.info("Initializing AWS S3 cloud sync for configuration sync implementation.");
+            try {
+                return new S3CloudSync(configLoader);
+            } catch (Exception e) {
+                log.error("Failed to create s3 cloud sync implementation.", e);
+            }
+        }
+        log.info("Initializing local sync for configuration sync implementation.");
+        return new LocalSync();
     }
 }

--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/DisclosureCache.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/DisclosureCache.java
@@ -3,9 +3,11 @@ package com.etsubu.stonksbot.scheduler.omxnordic;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+
 @AllArgsConstructor
 @Getter
 public class DisclosureCache {
     private final long timestamp;
-    private final int[] latestIds;
+    private final List<Integer> latestIds;
 }

--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/DisclosureCache.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/DisclosureCache.java
@@ -1,0 +1,11 @@
+package com.etsubu.stonksbot.scheduler.omxnordic;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class DisclosureCache {
+    private final long timestamp;
+    private final int[] latestIds;
+}

--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/NasdaqNordicDisclosures.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/NasdaqNordicDisclosures.java
@@ -1,6 +1,7 @@
 package com.etsubu.stonksbot.scheduler.omxnordic;
 
 import com.etsubu.stonksbot.configuration.ConfigLoader;
+import com.etsubu.stonksbot.configuration.ConfigurationSync;
 import com.etsubu.stonksbot.configuration.ServerConfig;
 import com.etsubu.stonksbot.discord.EventCore;
 import com.etsubu.stonksbot.utility.HttpApi;
@@ -25,23 +26,40 @@ import java.util.stream.Collectors;
 @EnableAsync
 public class NasdaqNordicDisclosures {
     private static final Logger log = LoggerFactory.getLogger(NasdaqNordicDisclosures.class);
+    private static final String CACHE_KEY = "disclosures";
     private static final int OMXH_ID = 0;
     private static final int FIRST_NORTH_ID = 1;
     private static final String[] DISCLOSURE_URL_TEMPLATES = {
-            "https://api.news.eu.nasdaq.com/news/query.action?type=json&showAttachments=true&showCnsSpecific=true&showCompany=true&callback=handleResponse&countResults=false&freeText=&market=Main%20Market%2C+Helsinki&cnscategory=&company=&fromDate=&toDate=&globalGroup=exchangeNotice&globalName=NordicMainMarkets&displayLanguage=fi&language=&timeZone=CET&dateMask=yyyy-MM-dd+HH%3Amm%3Ass&limit=20&start=%d&dir=DESC",
-            "https://api.news.eu.nasdaq.com/news/query.action?type=json&showAttachments=true&showCnsSpecific=true&showCompany=true&callback=handleResponse&countResults=false&freeText=&company=&market=First%20North+Finland&cnscategory=&fromDate=&toDate=&globalGroup=exchangeNotice&globalName=NordicFirstNorth&displayLanguage=en&language=&timeZone=CET&dateMask=yyyy-MM-dd+HH%3Amm%3Ass&limit=20&start=%d&dir=DESC"
+            "https://api.news.eu.nasdaq.com/news/query.action?type=json&showAttachments=true&showCnsSpecific=true&showCompany=true&callback=handleResponse&countResults=false&freeText=&market=Main%20Market%2C+Helsinki&cnscategory=&company=&fromDate=&toDate=&globalGroup=exchangeNotice&globalName=NordicMainMarkets&displayLanguage=fi&language=&timeZone=CET&dateMask=yyyy-MM-dd+HH%3Amm%3Ass&limit=20&dir=DESC&start=",
+            "https://api.news.eu.nasdaq.com/news/query.action?type=json&showAttachments=true&showCnsSpecific=true&showCompany=true&callback=handleResponse&countResults=false&freeText=&company=&market=First%20North+Finland&cnscategory=&fromDate=&toDate=&globalGroup=exchangeNotice&globalName=NordicFirstNorth&displayLanguage=en&language=&timeZone=CET&dateMask=yyyy-MM-dd+HH%3Amm%3Ass&limit=20&dir=DESC&start="
     };
-    private final int[] LATEST_DISCLOSURE_IDS = {-1, -1};
+    private final int[] LATEST_DISCLOSURE_IDS;
     private static final int DELAY_IN_TASK = 120; // 2min'
+    private static final long CACHE_TTL = 1000 * 60 * 60; // 1 hour
     private final Gson gson;
     private final EventCore eventCore;
     private final ConfigLoader configLoader;
+    private final ConfigurationSync configSync;
 
-    public NasdaqNordicDisclosures(ConfigLoader configLoader, EventCore eventCore) {
+    public NasdaqNordicDisclosures(ConfigLoader configLoader, EventCore eventCore, ConfigurationSync configSync) {
         this.configLoader = configLoader;
         this.eventCore = eventCore;
+        this.configSync = configSync;
         gson = new Gson();
-        log.info("Registering scheduled task {}", getClass().getName());
+        Optional<DisclosureCache> cache = configSync.loadConfiguration(CACHE_KEY, DisclosureCache.class);
+        log.info("Cache present == {}", cache.isPresent());
+        if(cache.isPresent()) {
+            long freshness = System.currentTimeMillis() - cache.get().getTimestamp();
+            if(freshness < 0 || freshness > CACHE_TTL) {
+                log.info("Cache is stale, {} ms. Starting from scratch", freshness);
+                LATEST_DISCLOSURE_IDS = new int[]{-1, -1};
+            } else {
+                LATEST_DISCLOSURE_IDS = cache.get().getLatestIds();
+                log.info("Cache loaded.");
+            }
+        } else {
+            LATEST_DISCLOSURE_IDS = new int[]{-1, -1};
+        }
     }
 
     public Optional<List<DisclosureItem>> parseResponse(String raw) {
@@ -100,7 +118,7 @@ public class NasdaqNordicDisclosures {
             if(start > 0) {
                 log.info("Querying extra items, starting with '{}'", start);
             }
-            String url = String.format(DISCLOSURE_URL_TEMPLATES[id], start);
+            String url = DISCLOSURE_URL_TEMPLATES[id] + start;
             Optional<String> response = HttpApi.sendGet(url);
             if(response.isEmpty()) {
                 return new LinkedList<>();
@@ -136,10 +154,13 @@ public class NasdaqNordicDisclosures {
         }
         try {
             List<DisclosureItem> disclosureItems = new ArrayList<>();
+            boolean initRun = false;
             for(int i = 0; i < LATEST_DISCLOSURE_IDS.length; i++) {
                 List<DisclosureItem> items = loadDisclosureItems(i);
                 if (LATEST_DISCLOSURE_IDS[i] != -1) {
                     disclosureItems.addAll(items);
+                } else {
+                    initRun = true;
                 }
                 if(items.size() > 0) {
                     LATEST_DISCLOSURE_IDS[i] = items.stream().map(DisclosureItem::getDisclosureId).max(Integer::compare).orElse(-1);
@@ -147,6 +168,9 @@ public class NasdaqNordicDisclosures {
             }
             if (!disclosureItems.isEmpty()) {
                 sendNewDisclosures(disclosureItems);
+                configSync.saveConfiguration(CACHE_KEY, new DisclosureCache(System.currentTimeMillis(), LATEST_DISCLOSURE_IDS));
+            } else if(initRun) {
+                configSync.saveConfiguration(CACHE_KEY, new DisclosureCache(System.currentTimeMillis(), LATEST_DISCLOSURE_IDS));
             }
         } catch (IOException | InterruptedException e) {
             log.error("HTTP request to api.news.eu.nasdaq.com failed", e);

--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/NasdaqNordicDisclosures.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/NasdaqNordicDisclosures.java
@@ -33,7 +33,7 @@ public class NasdaqNordicDisclosures {
             "https://api.news.eu.nasdaq.com/news/query.action?type=json&showAttachments=true&showCnsSpecific=true&showCompany=true&callback=handleResponse&countResults=false&freeText=&market=Main%20Market%2C+Helsinki&cnscategory=&company=&fromDate=&toDate=&globalGroup=exchangeNotice&globalName=NordicMainMarkets&displayLanguage=fi&language=&timeZone=CET&dateMask=yyyy-MM-dd+HH%3Amm%3Ass&limit=20&dir=DESC&start=",
             "https://api.news.eu.nasdaq.com/news/query.action?type=json&showAttachments=true&showCnsSpecific=true&showCompany=true&callback=handleResponse&countResults=false&freeText=&company=&market=First%20North+Finland&cnscategory=&fromDate=&toDate=&globalGroup=exchangeNotice&globalName=NordicFirstNorth&displayLanguage=en&language=&timeZone=CET&dateMask=yyyy-MM-dd+HH%3Amm%3Ass&limit=20&dir=DESC&start="
     };
-    private final int[] LATEST_DISCLOSURE_IDS;
+    private final List<Integer> LATEST_DISCLOSURE_IDS;
     private static final int DELAY_IN_TASK = 120; // 2min'
     private static final long CACHE_TTL = 1000 * 60 * 60; // 1 hour
     private final Gson gson;
@@ -52,13 +52,13 @@ public class NasdaqNordicDisclosures {
             long freshness = System.currentTimeMillis() - cache.get().getTimestamp();
             if(freshness < 0 || freshness > CACHE_TTL) {
                 log.info("Cache is stale, {} ms. Starting from scratch", freshness);
-                LATEST_DISCLOSURE_IDS = new int[]{-1, -1};
+                LATEST_DISCLOSURE_IDS = List.of(-1, -1);
             } else {
                 LATEST_DISCLOSURE_IDS = cache.get().getLatestIds();
                 log.info("Cache loaded.");
             }
         } else {
-            LATEST_DISCLOSURE_IDS = new int[]{-1, -1};
+            LATEST_DISCLOSURE_IDS = List.of(-1, -1);
         }
     }
 
@@ -128,13 +128,13 @@ public class NasdaqNordicDisclosures {
                 return new LinkedList<>();
             }
             List<DisclosureItem> itemList = items.get();
-            if(LATEST_DISCLOSURE_IDS[id] == -1 || itemList.get(itemList.size() - 1).getDisclosureId() < LATEST_DISCLOSURE_IDS[id]) {
+            if(LATEST_DISCLOSURE_IDS.get(id) == -1 || itemList.get(itemList.size() - 1).getDisclosureId() < LATEST_DISCLOSURE_IDS.get(id)) {
                 // Found earlier disclosure than the previously latest one
                 lastIdFound = true;
             }
             // Collect new disclosures
             newDisclosures.addAll(items.get().stream().filter(x ->
-                            Optional.ofNullable(x.getDisclosureId()).map(y -> y > LATEST_DISCLOSURE_IDS[id]).orElse(false) &&
+                            Optional.ofNullable(x.getDisclosureId()).map(y -> y > LATEST_DISCLOSURE_IDS.get(id)).orElse(false) &&
                                     Optional.ofNullable(x.getLanguage()).map(y -> y.equals("fi")).orElse(false))
                     .collect(Collectors.toList()));
             start += itemList.size();
@@ -155,15 +155,15 @@ public class NasdaqNordicDisclosures {
         try {
             List<DisclosureItem> disclosureItems = new ArrayList<>();
             boolean initRun = false;
-            for(int i = 0; i < LATEST_DISCLOSURE_IDS.length; i++) {
+            for(int i = 0; i < LATEST_DISCLOSURE_IDS.size(); i++) {
                 List<DisclosureItem> items = loadDisclosureItems(i);
-                if (LATEST_DISCLOSURE_IDS[i] != -1) {
+                if (LATEST_DISCLOSURE_IDS.get(i) != -1) {
                     disclosureItems.addAll(items);
                 } else {
                     initRun = true;
                 }
                 if(items.size() > 0) {
-                    LATEST_DISCLOSURE_IDS[i] = items.stream().map(DisclosureItem::getDisclosureId).max(Integer::compare).orElse(-1);
+                    LATEST_DISCLOSURE_IDS.set(i, items.stream().map(DisclosureItem::getDisclosureId).max(Integer::compare).orElse(-1));
                 }
             }
             if (!disclosureItems.isEmpty()) {

--- a/src/main/java/com/etsubu/stonksbot/scheduler/recommendations/CachedRecommendations.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/recommendations/CachedRecommendations.java
@@ -1,0 +1,14 @@
+package com.etsubu.stonksbot.scheduler.recommendations;
+
+import com.etsubu.stonksbot.inderes.model.RecommendationEntry;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter
+public class CachedRecommendations {
+    private final long timestamp;
+    private final Map<String, RecommendationEntry> entries;
+}


### PR DESCRIPTION
Currently recommendation changes or new disclosures are detect only after syncing the initial state on boot. Saving the state of these features on disk/cloud allows the application to resume previous state on restart without failing to detect any changes that occurred while the application was not running