### PR TITLE
Parse and include transaction disclosure numbers

### DIFF
--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/Model/DisclosureItem.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/Model/DisclosureItem.java
@@ -17,19 +17,20 @@ import java.util.Optional;
 @AllArgsConstructor
 public class DisclosureItem implements Comparable<DisclosureItem> {
     private static final Logger log = LoggerFactory.getLogger(DisclosureItem.class);
-    private final Integer disclosureId;
-    private final Integer categoryId;
-    private final String headline;
-    private final String language;
-    private final List<String> languages;
-    private final String company;
-    private final String cnsCategory;
-    private final String messageUrl;
-    private final String releaseTime;
-    private final String published;
-    private final String cnsTypeId;
-    private final List<OmxNewsAttachment> attachment;
-    private List<AttachmentFile> files;
+    private static final Integer TRANSACTION_CATEGORY_ID = 66;
+    protected final Integer disclosureId;
+    protected final Integer categoryId;
+    protected final String headline;
+    protected final String language;
+    protected final List<String> languages;
+    protected final String company;
+    protected final String cnsCategory;
+    protected final String messageUrl;
+    protected final String releaseTime;
+    protected final String published;
+    protected final String cnsTypeId;
+    protected final List<OmxNewsAttachment> attachment;
+    protected List<AttachmentFile> files;
 
     public boolean isValid() {
         return headline != null && company != null && cnsCategory != null && messageUrl != null;
@@ -52,6 +53,10 @@ public class DisclosureItem implements Comparable<DisclosureItem> {
                 }
             }
         }
+    }
+
+    public boolean isTransaction() {
+        return Optional.ofNullable(categoryId).map(x -> x.equals(TRANSACTION_CATEGORY_ID)).orElse(false);
     }
 
     @Override

--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/Model/TransactionItem.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/Model/TransactionItem.java
@@ -1,0 +1,111 @@
+package com.etsubu.stonksbot.scheduler.omxnordic.Model;
+
+import com.etsubu.stonksbot.utility.DoubleTools;
+import com.etsubu.stonksbot.utility.HttpApi;
+import com.etsubu.stonksbot.utility.NumberTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+public class TransactionItem extends DisclosureItem {
+    private static final Logger log = LoggerFactory.getLogger(TransactionItem.class);
+    private static final String TRANSACTION_TYPE_PREFIX = "Liiketoimen luonne: ";
+    private static final String VOLUME_PREFIX = "Volyymi: ";
+    private static final String AVG_PRICE_PREFIX = "Keskihinta: ";
+    protected String content;
+    protected String transactionType;
+    protected Long volume;
+    protected Double avgPrice;
+    protected String currency;
+
+    public TransactionItem(DisclosureItem item) {
+        super(item.disclosureId, item.categoryId, item.headline, item.language, item.languages, item.company,
+                item.cnsCategory, item.messageUrl, item.releaseTime, item.published, item.cnsTypeId, item.attachment,
+                item.files);
+        if(isTransaction() && messageUrl != null) {
+            // Load transaction information
+            try {
+                Optional<String> content = HttpApi.sendGet(messageUrl);
+                if(content.isEmpty()) {
+                    log.error("Failed to load disclosure content {}", messageUrl);
+                } else {
+                    this.content = content.get();
+                }
+            } catch (IOException | InterruptedException e) {
+                log.error("Failed to load disclosure content {}", messageUrl);
+            }
+        } else {
+            throw new IllegalArgumentException("No message url present or the disclosure is not a transaction");
+        }
+    }
+
+    public void loadValues() {
+        if(content != null) {
+            int typeIndex = content.indexOf(TRANSACTION_TYPE_PREFIX);
+            int volumeIndex = content.lastIndexOf(VOLUME_PREFIX);
+            int avgPriceIndex = content.lastIndexOf(AVG_PRICE_PREFIX);
+            transactionType = content.substring(typeIndex + TRANSACTION_TYPE_PREFIX.length(), content.indexOf('<', typeIndex + TRANSACTION_TYPE_PREFIX.length()));
+            String volumeStr = content.substring(volumeIndex + VOLUME_PREFIX.length(), content.indexOf(' ', volumeIndex + VOLUME_PREFIX.length()))
+                    .replaceAll(" ", "")
+                    .trim();
+            String avgPriceStr = content.substring(avgPriceIndex + AVG_PRICE_PREFIX.length());
+            currency = avgPriceStr.substring(avgPriceStr.indexOf(' ') + 1, avgPriceStr.indexOf('<'));
+
+            avgPriceStr = avgPriceStr.substring(0, avgPriceStr.indexOf(' '))
+                    .replaceAll(",", ".")
+                    .replaceAll(" ", "")
+                    .trim();
+            try {
+                volume = Long.parseLong(volumeStr);
+                avgPrice = Double.parseDouble(avgPriceStr);
+            } catch (NumberFormatException e) {
+                log.error("Failed to parse volume or price '{}', '{}'", volumeStr, avgPriceStr);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (isValid()) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("**Otsikko**: `")
+                    .append(headline)
+                    .append("`\n**Yhtiö**: `")
+                    .append(company)
+                    .append("`\n**Tapahtumalaji**: `")
+                    .append(cnsCategory)
+                    .append("`\n**Ilmoitus**: ")
+                    .append(messageUrl);
+            if(volume != null && avgPrice != null && transactionType != null) {
+                builder.append("`\n**Toimeksiannon tyyppi**: `")
+                        .append(transactionType);
+                if(avgPrice == 0) {
+                    builder.append("`\n**Volyymi**: `")
+                            .append(NumberTools.formatToUserFriendly(volume)).append('`');
+                } else {
+                    builder.append("`\n**Summa**: `")
+                            .append(NumberTools.formatToUserFriendly(DoubleTools.round(avgPrice * volume, 0)))
+                            .append(' ')
+                            .append(currency).append('`');
+                }
+            }
+            builder.append("\n````");
+            return builder.toString();
+        } else {
+            return "Missing news item info";
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+}

--- a/src/main/java/com/etsubu/stonksbot/scheduler/recommendations/InderesRecommendations.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/recommendations/InderesRecommendations.java
@@ -134,7 +134,7 @@ public class InderesRecommendations {
             builder.append("Suositus: ").append(from.getRecommendationText()).append('\n');
             builder.append("Riski: ").append(from.getRisk()).append("\n```");
         } else {
-            Num targetPrice = DecimalNum.valueOf(v.first.getTarget().replaceAll(",", "."));
+            Num targetPrice = DecimalNum.valueOf(to.getTarget().replaceAll(",", "."));
             builder.append("```\n(Inderes)\nSeurannan aloitus:");
             builder.append("\nNimi: ").append(to.getName()).append('\n');
             builder.append("Tavoitehinta: ").append(to.getTarget()).append('\n');

--- a/src/main/java/com/etsubu/stonksbot/utility/NumberTools.java
+++ b/src/main/java/com/etsubu/stonksbot/utility/NumberTools.java
@@ -1,0 +1,25 @@
+package com.etsubu.stonksbot.utility;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+public class NumberTools {
+    public static String formatToUserFriendly(double value) {
+        DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+        DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
+
+        symbols.setGroupingSeparator(' ');
+        formatter.setDecimalFormatSymbols(symbols);
+        return formatter.format(value).trim();
+    }
+    public static String formatToUserFriendly(long value) {
+        DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+        DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
+
+        symbols.setGroupingSeparator(' ');
+        formatter.setDecimalFormatSymbols(symbols);
+        return formatter.format(value).trim();
+    }
+}


### PR DESCRIPTION
When posting disclosures of "transaction" type, the type of the transaction such as stock reward/buy/sell, volume, and total sum of the transaction are included in the posted notification so the details can be seen without having to open the link to the disclosure.