### PR TITLE
Remove extra backtick from posted disclosure urls

### DIFF
--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/Model/TransactionItem.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/Model/TransactionItem.java
@@ -80,7 +80,7 @@ public class TransactionItem extends DisclosureItem {
                     .append("`\n**Ilmoitus**: ")
                     .append(messageUrl);
             if(volume != null && avgPrice != null && transactionType != null) {
-                builder.append("`\n**Toimeksiannon tyyppi**: `")
+                builder.append("\n**Toimeksiannon tyyppi**: `")
                         .append(transactionType);
                 if(avgPrice == 0) {
                     builder.append("`\n**Volyymi**: `")


### PR DESCRIPTION
Fixes a bug where the urls of posted disclosure links contained an extra backtick at the end of url