### PR TITLE
Upgrade dependencies to latest and address log4j2 CVE-2021-44228 vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id "io.freefair.lombok" version "6.2.0"
-    id "org.owasp.dependencycheck" version "6.4.1.1"
+    id "io.freefair.lombok" version "6.3.0"
+    id "org.owasp.dependencycheck" version "6.5.0.1"
     id "com.github.spotbugs" version "4.7.1"
     id "com.github.johnrengelman.shadow" version "7.1.0"
     id "com.github.ben-manes.versions" version "0.39.0"
-    id 'se.patrikerdes.use-latest-versions' version '0.2.17'
+    id 'se.patrikerdes.use-latest-versions' version '0.2.18'
     id "java"
 }
 
@@ -64,25 +64,25 @@ spotbugsTest {
 }
 
 dependencies {
-    implementation 'org.springframework:spring-core:5.3.12'
-    implementation 'org.springframework:spring-beans:5.3.12'
-    implementation 'org.springframework:spring-context:5.3.12'
+    implementation 'org.springframework:spring-core:5.3.13'
+    implementation 'org.springframework:spring-beans:5.3.13'
+    implementation 'org.springframework:spring-context:5.3.13'
     implementation 'org.yaml:snakeyaml:1.29'
     implementation 'org.ta4j:ta4j-core:0.14'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'org.json:json:20210307'
-    implementation ('net.dv8tion:JDA:4.3.0_339') {
+    implementation 'org.json:json:20211205'
+    implementation ('net.dv8tion:JDA:5.0.0-alpha.2') {
         exclude module: 'opus-java'
     }
     implementation 'org.slf4j:slf4j-api:2.0.0-alpha5'
-    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
-    implementation 'org.apache.logging.log4j:log4j-api:2.14.1'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.99'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-    testImplementation 'org.mockito:mockito-core:4.0.0'
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.0.0'
+    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.128'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.1.0'
 }
 
 group = 'com.etsubu.stonksbot'


### PR DESCRIPTION
Upgrades all dependencies to latest and fixes log4j2 CVE-2021-44228 vulnerability by upgrading it to 2.15.0 version https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
