### PR TITLE
Upgrade dependencies to latest and mitigate log4j CVE-2021-45105

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "io.freefair.lombok" version "6.3.0"
     id "org.owasp.dependencycheck" version "6.5.0.1"
     id "com.github.spotbugs" version "4.7.1"
-    id "com.github.johnrengelman.shadow" version "7.1.0"
+    id "com.github.johnrengelman.shadow" version "7.1.1"
     id "com.github.ben-manes.versions" version "0.39.0"
     id 'se.patrikerdes.use-latest-versions' version '0.2.18'
     id "java"
@@ -64,10 +64,10 @@ spotbugsTest {
 }
 
 dependencies {
-    implementation 'org.springframework:spring-core:5.3.13'
-    implementation 'org.springframework:spring-beans:5.3.13'
-    implementation 'org.springframework:spring-context:5.3.13'
-    implementation 'org.yaml:snakeyaml:1.29'
+    implementation 'org.springframework:spring-core:5.3.14'
+    implementation 'org.springframework:spring-beans:5.3.14'
+    implementation 'org.springframework:spring-context:5.3.14'
+    implementation 'org.yaml:snakeyaml:1.30'
     implementation 'org.ta4j:ta4j-core:0.14'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.json:json:20211205'
@@ -75,14 +75,14 @@ dependencies {
         exclude module: 'opus-java'
     }
     implementation 'org.slf4j:slf4j-api:2.0.0-alpha5'
-    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.16.0'
+    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.17.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.0'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.129'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    testImplementation 'org.mockito:mockito-core:4.1.0'
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.1.0'
+    testImplementation 'org.mockito:mockito-core:4.2.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.2.0'
 }
 
 group = 'com.etsubu.stonksbot'


### PR DESCRIPTION
Mitigate latest log4j 2.16 vulnerability CVE-2021-45105