### PR TITLE
Extend nasdaq nordic disclosure language filter

### DIFF
--- a/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/NasdaqNordicDisclosures.java
+++ b/src/main/java/com/etsubu/stonksbot/scheduler/omxnordic/NasdaqNordicDisclosures.java
@@ -136,7 +136,8 @@ public class NasdaqNordicDisclosures {
             // Collect new disclosures
             newDisclosures.addAll(items.get().stream().filter(x ->
                             Optional.ofNullable(x.getDisclosureId()).map(y -> y > LATEST_DISCLOSURE_IDS.get(id)).orElse(false) &&
-                                    Optional.ofNullable(x.getLanguage()).map(y -> y.equals("fi")).orElse(false))
+                                    (Optional.ofNullable(x.getLanguage()).map(y -> y.equals("fi")).orElse(false)
+                                    || Optional.ofNullable(x.getLanguages()).map(y -> y.contains("fi")).orElse(false)))
                     .collect(Collectors.toList()));
             start += itemList.size();
         }


### PR DESCRIPTION
Extends disclosure language filter to those that contain "fi" as languages, even if the item has some other language definitions as well