### PR TITLE
Upgrade dependencies to latest and address log4j CVE-2021-44832 vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "io.freefair.lombok" version "6.3.0"
-    id "org.owasp.dependencycheck" version "6.5.0.1"
+    id "org.owasp.dependencycheck" version "6.5.1"
     id "com.github.spotbugs" version "4.7.1"
-    id "com.github.johnrengelman.shadow" version "7.1.1"
-    id "com.github.ben-manes.versions" version "0.39.0"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id "com.github.ben-manes.versions" version "0.40.0"
     id 'se.patrikerdes.use-latest-versions' version '0.2.18'
     id "java"
 }
@@ -71,14 +71,14 @@ dependencies {
     implementation 'org.ta4j:ta4j-core:0.14'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.json:json:20211205'
-    implementation ('net.dv8tion:JDA:5.0.0-alpha.2') {
+    implementation ('net.dv8tion:JDA:5.0.0-alpha.3') {
         exclude module: 'opus-java'
     }
     implementation 'org.slf4j:slf4j-api:2.0.0-alpha5'
-    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.17.0'
-    implementation 'org.apache.logging.log4j:log4j-core:2.17.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.17.0'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.129'
+    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.131'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation 'org.mockito:mockito-core:4.2.0'


### PR DESCRIPTION
Upgrade dependencies to latest and address log4j CVE-2021-44832 vulnerability